### PR TITLE
Removed reference to H5I_REFERENCE in c5i-grovel.lisp

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ install:
   - curl -L https://raw.githubusercontent.com/roswell/roswell/release/scripts/install-for-ci.sh | sh
   - pwd
   - test -f "$HOME/szip/lib/libsz.so" || ( curl -L https://support.hdfgroup.org/ftp/lib-external/szip/2.1.1/src/szip-2.1.1.tar.gz | tar xz ; cd szip-2.1.1; ./configure --prefix=$HOME/szip ; make install )
-  - test -f "$HOME/hdf5/lib/libhdf5.a" || ( curl -L https://support.hdfgroup.org/ftp/HDF5/current/src/hdf5-1.10.1.tar.gz | tar xz ; cd hdf5-1.10.1; ./configure --prefix=$HOME/hdf5 --with-szlib=$HOME/szip ; make install )
+  - test -f "$HOME/hdf5/lib/libhdf5.a" || ( curl -L https://support.hdfgroup.org/ftp/HDF5/current/src/hdf5-1.10.5.tar.bz2  | tar xj ; cd hdf5-1.10.5; ./configure --prefix=$HOME/hdf5 --with-szlib=$HOME/szip ; make install )
 
 cache:
   directories:

--- a/src/h5i-grovel.lisp
+++ b/src/h5i-grovel.lisp
@@ -25,7 +25,6 @@
        ((:H5I-DATASPACE   "H5I_DATASPACE"))
        ((:H5I-DATASET     "H5I_DATASET"))
        ((:H5I-ATTR        "H5I_ATTR"))
-       ((:H5I-REFERENCE   "H5I_REFERENCE"))
        ((:H5I-VFL         "H5I_VFL"))
        ((:H5I-GENPROP-CLS "H5I_GENPROP_CLS"))
        ((:H5I-GENPROP-LST "H5I_GENPROP_LST"))


### PR DESCRIPTION
Build fails on hdf5-1.12 due to H5I_REFERENCE being removed from headers....
Removed H5I_REFERENCE from c5i-grovel.lisp
Per hdf5-1.12.0/release_docs/HISTORY-1_10_0-1_12_0.txt
    - Remove H5I_REFERENCE from the library
      This ID class was never used by the library and has been removed.
      (DER - 2018/12/08, HDFFV-10252)